### PR TITLE
Add the feature of injecting external variables into echarts.

### DIFF
--- a/src/components/Echarts/renderChart.js
+++ b/src/components/Echarts/renderChart.js
@@ -16,6 +16,7 @@ export default function renderChart(props) {
     eChartsContainer.style.background = "${props.backgroundColor}";
     echarts.registerMap('world', ${JSON.stringify(worldJson)});
     const myChart = echarts.init(eChartsContainer, '${props.themeName}');
+    let props = ${toString(props)};
     let clickName = {}
     myChart.on('mousedown', (params)=>{
       clickName = {


### PR DESCRIPTION
Because the JavaScript code of echarts is injected into `WebView` component, the external variable value is inaccessible in the formatter function of echarts:
```
// echarts will not show
const unit = res.data.unit;
const option = 
{
    yAxis: {
        axisLabel: {
            formatter(value) {
                // unit is inaccessible
                return value + unit;
            }
        }
    }
    ......
}
......
render() {
    return (
        <RNEChartsPro
            option={option}
            height={180}
            width={Dimensions.get('window').width}
        />
    );
}
......
```

The PR will resolve this issue. We can create a variable value in the injected code of echarts, the value will be accessable in the formatter function:
```
// echarts will render well
const unit = res.data.unit;
const option = 
{
    yAxis: {
        axisLabel: {
            formatter(value) {
                return value + props.unit;
            }
        }
    }
    ......
}
......
render() {
    return (
        <RNEChartsPro
            option={option}
            height={180}
            width={Dimensions.get('window').width}
            unit={unit}
        />
    );
}
......
```