### PR TITLE
[feature] Support line feed char "\n" in the "formatter function".

### DIFF
--- a/src/util/toString.js
+++ b/src/util/toString.js
@@ -1,7 +1,8 @@
 export default function toString(obj) {
   let result = JSON.stringify(obj, function (key, val) {
     if (typeof val === "function") {
-      return `~--demo--~${val}~--demo--~`;
+      // This "replace function" is used to remove the useless line feeds among code.
+      return `~--demo--~${val}~--demo--~`.replace(/\n/g, '');
     }
     return val;
   });
@@ -10,7 +11,7 @@ export default function toString(obj) {
     result = result
       .replace('"~--demo--~', "")
       .replace('~--demo--~"', "")
-      .replace(/\\n/g, "")
+      .replace(/\\\\/g, '\\') // When the formatter function convert to string, '\n' in the return string will be replaced by '\\n', this "replace function" will replace it back to line feed '\n'.
       .replace(/\\\"/g, '"'); //最后一个replace将release模式中莫名生成的\"转换成"
   } while (result.indexOf("~--demo--~") >= 0);
   // 添加此行把unicode转为中文（否则formatter函数中含有中文在release版本中显示不出来）


### PR DESCRIPTION
## Summary

Support the line feed char `\n` in the **formatter function**. Without this PR, Echarts will display blank when use `\n` in the **formatter function**.

In the `toString` util function, every `\n` will be removed. This PR will keep `\n` in the return string of the **formatter function**.

## Test plan

Use the line feed char `\n` in the **formatter function**.

Without this PR, Echarts is blank.

With this PR, rendering well with line feed where you want.

```javascript
<RNEChartsPro
  width="100%"
  height={300}
  option={{
    xAxis: {
      type: 'category',
      data: ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'],
      axisLabel: {
        formatter: (value: string) => {
          return value + '\n' + '(\\n)';
        },
      },
    },
    yAxis: {
      type: 'value'
    },
    series: [
      {
        data: [150, 230, 224, 218, 135, 147, 260],
        type: 'line'
      }
    ]
  }}
/>
```

## Compatibility

For both **Android** and **iOS**.