### PR TITLE
[feature] add new props "enableParseStringFunction"

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -11,6 +11,7 @@ declare function RNEChartsPro(props: {
   backgroundColor?: string;
   formatterVariable?: object;
   eventActions?:object;
+  enableParseStringFunction?:boolean;
   legendSelectChanged?(result: string);
   onDataZoom?(result: string);
   onPress?(result: string);

--- a/src/util/toString.js
+++ b/src/util/toString.js
@@ -1,8 +1,15 @@
 export default function toString(obj) {
   let result = JSON.stringify(obj, function (key, val) {
     if (typeof val === "function") {
-      // This "replace function" is used to remove the useless line feeds among code.
-      return `~--demo--~${val}~--demo--~`.replace(/\n/g, "");
+      let newVal = `~--demo--~${val}~--demo--~`;
+      // Simplify code by removing line breaks between codes
+      newVal = newVal.replace(/\n/g, "");
+      /* When the function such as "formatter" injects into the renderChart.js and as a string,
+       * '\n' in the string variable of formatter function will be converted to '\\n',
+       * this replace function will replace it back to '\n' for line feed.
+       */
+      newVal = newVal.replace(/\\n/g, "\n");
+      return newVal;
     }
     return val;
   });
@@ -11,7 +18,6 @@ export default function toString(obj) {
     result = result
       .replace('"~--demo--~', "")
       .replace('~--demo--~"', "")
-      .replace(/\\\\/g, "\\") // When the formatter function convert to string, '\n' in the return string will be replaced by '\\n', this "replace function" will replace it back to line feed '\n'.
       .replace(/\\\"/g, '"'); //最后一个replace将release模式中莫名生成的\"转换成"
   } while (result.indexOf("~--demo--~") >= 0);
   // 添加此行把unicode转为中文（否则formatter函数中含有中文在release版本中显示不出来）


### PR DESCRIPTION
## Summary

This PR allows the developers to resolve the Hermes bytecode conversion issue for the Echarts option's function. 
[Related issue](https://github.com/supervons/react-native-echarts-pro/issues/35)

The default value of "**enableParseStringFunction**" is "false". It will not affect any original code logic whether the value is "true" or "false". And if the prop is set to "true", any Echarts option's function in string format and starting with the string "function" will be converted to a normal function in the WebView environment dynamically.

Because the function is in string format, the Hermes bytecode conversion will not work. This solution will work as expected in both debug and release modes. 

There is also a **'show source'** solution from the Hermes official, but from my side, it only works on my Android release environment for now.

## Test Plan 

#### Code:

```JavaScript
// Echarts option
const option = {
  xAxis: {
    type: 'category',
    data: ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'],
    axisLabel: {
      formatter: `function (val) {
        return val + '\\n' + '(week)';
      }`,
    },
  },
  yAxis: {
    type: 'value',
    axisLabel: {
      formatter: `function (val) {
        return formatterVariable.currency + val;
      }`,
      textStyle: {
        color: `function (value, index) {
          return value >= 200 ? 'green' : 'red';
        }`,
      },
    },
  },
  series: [
    {
      data: [150, 230, 224, 218, 135, 147, 260],
      type: 'line',
    },
  ],
};

// Echarts view
<RNEChartsPro
  style={{width: Dimensions.get('window').width}}
  option={option}
  formatterVariable={{currency: '$'}}
  enableParseStringFunction
/>
```

#### Running result:

<img src="https://user-images.githubusercontent.com/26167428/212275745-95490ecd-d12e-4fa0-9708-b9c400f68594.png" width = "300" alt="demo" align=center />

#### Other notes:

The normal function using 'show source' will also work like before, there is no effect on the origin code logic(even if not using the Hermes engine).

