### PR TITLE
[fix] Remove useless "replace" function

### DIFF
--- a/src/util/toString.js
+++ b/src/util/toString.js
@@ -17,8 +17,7 @@ export default function toString(obj) {
   do {
     result = result
       .replace('"~--demo--~', "")
-      .replace('~--demo--~"', "")
-      .replace(/\\\"/g, '"'); //最后一个replace将release模式中莫名生成的\"转换成"
+      .replace('~--demo--~"', "");
   } while (result.indexOf("~--demo--~") >= 0);
   // 添加此行把unicode转为中文（否则formatter函数中含有中文在release版本中显示不出来）
   result = unescape(result.replace(/\\u/g, "%u"));


### PR DESCRIPTION
### Summary

This PR removes [this line of the code](https://github.com/supervons/react-native-echarts-pro/blob/5b8d517e1ecbd76ed38e3394ae4691694d1ff19e/src/util/toString.js#L21C7-L21C7). This line of the code will make the sign `"` not working in the formatter string function.

After removing it, I tested it on debug and release mode and the charts are rendering well on iOS and Android.

### Related issue

https://github.com/supervons/react-native-echarts-pro/issues/96#issuecomment-1449607617

### Test case

Before removing the line of the code, the below chart will not be rendered well because of the sign `"`  in the fromatter string function.

After removing the line of the code, the below chart will be rendered well.

```javascript
function renderChart() {
  const pieOption = {
    tooltip: {
      formatter: `(param) => {
        return param.marker + "&nbsp;&nbsp;" + param.name + "：" + param.value + "<br>";
      }`,
    },
    series: [
      {
        name: 'Source',
        type: 'pie',
        legendHoverLink: true,
        hoverAnimation: true,
        avoidLabelOverlap: true,
        startAngle: 180,
        radius: '55%',
        center: ['50%', '35%'],
        data: [
          {value: 105.2, name: 'android'},
          {value: 310, name: 'iOS'},
          {value: 234, name: 'web'},
        ],
        label: {
          normal: {
            show: true,
            textStyle: {
              fontSize: 12,
              color: '#23273C',
            },
          },
        },
      },
    ],
  };
  return (
    <View style={{height: 300, paddingTop: 25}}>
      <RNEChartsPro
        enableParseStringFunction={true}
        height={250}
        option={pieOption}
      />
    </View>
  );
}
```